### PR TITLE
Fix how we find the chunkGroup name when there runtime entry is enabled

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -90,7 +90,7 @@ Plugin.prototype.apply = function(compiler) {
       var files = chunkGroup.chunks.reduce(function (files, chunk) {
         return [...files, ...getFilesFromChunk(chunk)]
       }, [])
-      chunks[chunkGroup.runtimeChunk.name] = files
+      chunks[chunkGroup.options.name] = files
     })
 
     var output = {


### PR DESCRIPTION
chunkGroup.runtimeChunk.name is always 'runtime' when you turn on webpack's `runtimeChunk: 'single'`, so chunkGroup.options.name is more reliable.